### PR TITLE
Updated other-datastructures.ipynb - added full path to the isdir() method

### DIFF
--- a/notebooks/lesson2/other-datastructures.ipynb
+++ b/notebooks/lesson2/other-datastructures.ipynb
@@ -59,8 +59,9 @@
       "outputs": [],
       "source": [
         "import os\n",
-        "for item in os.listdir('sample_data'):\n",
-        "  if os.path.isdir(item):\n",
+        "path = 'sample_data'\n",
+        "for item in os.listdir(path):\n",
+        "  if os.path.isdir(os.path.join(path, item)):\n",
         "    print(\"This is a directory {0}\".format(item))\n",
         "  else:\n",
         "    print(\"This is a file: {0}\".format(item))"


### PR DESCRIPTION
os.path.isdir() method only works with the full path to the folder. This has been corrected.